### PR TITLE
docs: fix connector doc regressions

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -41,7 +41,7 @@ Carefully save the token value.
 </Step>
 </Steps>
 
- Next, move on to the connector configuration instructions.
+Next, move on to the connector configuration instructions.
 
 ### Option 2: Set up AppRole authentication
 
@@ -86,7 +86,7 @@ Carefully save the `secret_id` value.
 </Step>
 </Steps>
 
- Next, move on to the connector configuration instructions.
+Next, move on to the connector configuration instructions.
 
 ## Configure the HashiCorp Vault connector 
 
@@ -229,7 +229,7 @@ Check that the connector data uploaded correctly. In C1, click **Apps**. On the 
 </Step>
 </Steps>
 
- Your HashiCorp Vault connector is now pulling access data into C1.
+Your HashiCorp Vault connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -41,7 +41,7 @@ Carefully save the token value.
 </Step>
 </Steps>
 
-**That's it!** Next, move on to the connector configuration instructions.
+ Next, move on to the connector configuration instructions.
 
 ### Option 2: Set up AppRole authentication
 
@@ -86,7 +86,7 @@ Carefully save the `secret_id` value.
 </Step>
 </Steps>
 
-**That's it!** Next, move on to the connector configuration instructions.
+ Next, move on to the connector configuration instructions.
 
 ## Configure the HashiCorp Vault connector 
 
@@ -229,7 +229,7 @@ Check that the connector data uploaded correctly. In C1, click **Apps**. On the 
 </Step>
 </Steps>
 
-**That's it!** Your HashiCorp Vault connector is now pulling access data into C1.
+ Your HashiCorp Vault connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
## Summary

This PR corrects issues in the connector docs that were caught during a sync to the ConductorOne docs site. Specific fixes:

- Remove added \`**That's it!**\` phrases (sync bot prepended this to 3 existing plain-text sentences; restoring original text)

These corrections prevent the sync bot from reintroducing regressions on future runs.